### PR TITLE
Removes drawer when open "About"

### DIFF
--- a/lib/widgets/lethean_drawer.dart
+++ b/lib/widgets/lethean_drawer.dart
@@ -76,6 +76,7 @@ class LetheanDrawer extends StatelessWidget {
                 style: Theme.of(context).textTheme.subtitle1,
               ),
               onTap: () async {
+                Navigator.pop(context);
                 // Information about app.
                 PackageInfo packageInfo = await PackageInfo.fromPlatform();
                 showAboutDialog(


### PR DESCRIPTION
This one was actually included in the 0.1.3 release. Forgot to commit before making the realease.
Moving it to master to get code same as release. Will be a small diff in release source code download files but not worth making a new release for this I think 